### PR TITLE
Replace deprecated plugins

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,8 +12,8 @@ version_regexp = ^(\d+(?:\.\d+)+)$
 [MetaJSON]
 [PkgVersion]
 [PodSyntaxTests]
-[NoTabsTests]
-[EOLTests]
+[Test::NoTabs]
+[Test::EOL]
 
 [MetaResources]
 repository.type = git


### PR DESCRIPTION
`NoTabsTests` and `EOLTests` are deprecated and should be replaced by `Test::NoTabs` and `Test::EOL`.
 